### PR TITLE
Remove jersey-core exclusion for better spark-on-yarn integration

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -116,10 +116,6 @@
           <groupId>javax.servlet</groupId>
           <artifactId>servlet-api</artifactId>
         </exclusion>
-        <exclusion>
-          <groupId>com.sun.jersey</groupId>
-          <artifactId>jersey-core</artifactId>
-        </exclusion>
       </exclusions>
       <scope>${hadoop.scope}</scope>
     </dependency>


### PR DESCRIPTION
Remove jersey-core exclusion for better spark-on-yarn integration especially for batches